### PR TITLE
Remove quotes from multi args.

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,7 +67,7 @@ function parseSwitches(options) {
 			return ('/' + key + ':' + qualifier + val + qualifier);
 		}
 		if (val instanceof Array) {
-			return ('/' + key + ':"' + val.join(',') + '"');
+			return ('/' + key + ':' + val.join(','));
 		}
 	});
 

--- a/test/test.js
+++ b/test/test.js
@@ -148,7 +148,7 @@ var path = require('path');
 
 				expect(nunit.getArguments(opts, [])).to.deep.equal(
 					[
-						'/exclude:"Acceptance,Integration"'
+						'/exclude:Acceptance,Integration'
 					]);
 			}); // end it
 		}); // end describe


### PR DESCRIPTION
It looks like nunit doesn't treat quotes as a qualifier, at least for multi args, but reads them in as part of the value. `/run:"My.Namespace"` does not work but `/run:My.Namespace` does. I couldn't seem to find any info on the google about how nunit handles spaces in multi args and didn't want to dig through nunit source to find out so just removed the quotes. 
