### PR TITLE
Make the command line switch aware of OS so that it works on non windows platform under mono

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,19 +65,23 @@ runner.getArguments = function (options, assemblies) {
 function parseSwitches(options) {
 	var filtered,
 		switches;
+
+	var isWin = /^win/.test(process.platform);
+// when running under mono on linux/mac switches must be specified with a - not a /	
+	var switchChar = isWin ? '/' : '-';
 	switches = _.map(options, function (val, key) {
 		if (typeof val === 'boolean') {
 			if (val) {
-				return ('/' + key);
+				return (switchChar + key);
 			}
 			return undefined;
 		}
 		if (typeof val === 'string') {
 			var qualifier = val.trim().indexOf(' ') > -1 ? '"' : '';
-			return ('/' + key + ':' + qualifier + val + qualifier);
+			return (switchChar + key + ':' + qualifier + val + qualifier);
 		}
 		if (val instanceof Array) {
-			return ('/' + key + ':' + val.join(','));
+			return (switchChar + key + ':' + val.join(','));
 		}
 	});
 

--- a/test/test.js
+++ b/test/test.js
@@ -117,6 +117,9 @@ var path = require('path');
 			});
 
 			it('Should have correct options with options and assemblies.', function () {
+				var isWin = /^win/.test(process.platform);
+				var switchChar = isWin ? '/' : '-';
+
 				opts = {
 					executable: 'C:\\nunit\\bin\\nunit-console.exe',
 					options   : {
@@ -131,15 +134,18 @@ var path = require('path');
 
 				expect(nunit.getArguments(opts, assemblies)).to.deep.equal(
 					[
-						'/nologo',
-						'/config:Release',
-						'/transform:myTransform.xslt',
+						switchChar + 'nologo',
+						switchChar + 'config:Release',
+						switchChar + 'transform:myTransform.xslt',
 						'First.Test.dll',
 						'Second.Test.dll'
 					]);
 			});
 
 			it('Should properly format multi args.', function () {
+				var isWin = /^win/.test(process.platform);
+				var switchChar = isWin ? '/' : '-';
+
 				opts = {
 					options: {
 						exclude: ['Acceptance', 'Integration']
@@ -148,7 +154,7 @@ var path = require('path');
 
 				expect(nunit.getArguments(opts, [])).to.deep.equal(
 					[
-						'/exclude:Acceptance,Integration'
+						switchChar + 'exclude:Acceptance,Integration'
 					]);
 			}); // end it
 		}); // end describe


### PR DESCRIPTION
*Make the command line switch aware of OS so that it uses the correct character when running under mono on linux/mac.*

When running under mono on Linux (and I presume it would be the same on a mac) the command line switches passed to nunit need to be a dash rather than a slash. e.g. -nologo rather than /nologo. I added a check for the OS and if its not windows set the switch character to '-' else '/'.

Tested on Ubuntu 15.10 running mono 4.2.1, with NUnit Runners 2.6.4.