### PR TITLE
Added check for output file before creating the TeamCity output.

### DIFF
--- a/index.js
+++ b/index.js
@@ -141,7 +141,9 @@ function run(stream, files, options) {
 
 	child.on('close', function (code) {
 		if (options.teamcity) {
-			gutil.log.apply(null, teamcity(fs.readFileSync(options.options.result, 'utf8')));
+			if (fs.existsSync(options.options.result))
+				gutil.log.apply(null, teamcity(fs.readFileSync(options.options.result, 'utf8')));
+			else fail(stream, 'NUnit output not found: ' + options.options.result);
 		}
 		if (cleanupTempFiles) {
 			cleanupTempFiles();


### PR DESCRIPTION
Running into a scenario where NUnit fails to write the output file and then the teamcity logic in the gulp task fails because it can't find it. This scenario is causing the gulp task to fail silently so added a check for the file and explicit failure if it doesn't exist.