### PR TITLE
Add continueOnError option

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,11 @@ nunit({
     // https://confluence.jetbrains.com/display/TCD8/Build+Script+Interaction+with+TeamCity
     teamcity: true|false,
 
+    // Do not throw a gulp error and stop the stream on failing NUnit tests.
+    // This is useful on TeamCity, where tests can be muted after the tests
+    // are run, which allow the build to pass.
+    continueOnError: true|false,
+
     // The options below map directly to the NUnit console runner. See here
     // for more info: http://www.nunit.org/index.php?p=consoleCommandLine&r=2.6.3
     options: {

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ var _ = require('lodash'),
 	path = require('path'),
 	temp = require('temp'),
 	fs = require('fs'),
-	teamcity = require('./lib/teamcity'),
+	teamcity = require('./teamcity'),
 
 	PLUGIN_NAME = 'gulp-nunit-runner',
 	NUNIT_CONSOLE = 'nunit-console.exe',
@@ -48,7 +48,7 @@ runner.getExecutable = function (options) {
 	// trim any existing surrounding quotes and then wrap in ""
 	executable = trim(options.executable, '\\s', '"', "'");
 	return !path.extname(options.executable) ?
-		path.join(executable, consoleRunner) : executable;
+			path.join(executable, consoleRunner) : executable;
 };
 
 runner.getArguments = function (options, assemblies) {
@@ -114,7 +114,7 @@ function run(stream, files, options) {
 
 	if (!options.options.result && options.teamcity) {
 		temp.track();
-		options.options.result = temp.path({suffix: '.xml'});
+		options.options.result = temp.path({ suffix: '.xml' });
 		cleanupTempFiles = temp.cleanup;
 	}
 
@@ -141,14 +141,20 @@ function run(stream, files, options) {
 
 	child.on('close', function (code) {
 		if (options.teamcity) {
-			gutil.log.apply(null, teamcity(fs.readFileSync(options.options.result, 'utf8')));
+			if (fs.existsSync(options.options.result)) {
+				gutil.log.apply(null, teamcity(fs.readFileSync(options.options.result, 'utf8')));
+			} else {
+				fail(stream, 'NUnit output not found: ' + options.options.result);
+			}
 		}
 		if (cleanupTempFiles) {
 			cleanupTempFiles();
 		}
 		if (code !== 0) {
 			gutil.log(gutil.colors.red('NUnit tests failed.'));
-			fail(stream, 'NUnit tests failed.');
+			if (!options.continueOnError) {
+				fail(stream, 'NUnit tests failed.');
+			}
 		} else {
 			gutil.log(gutil.colors.cyan('NUnit tests passed'));
 		}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-nunit-runner",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "A Gulp.js plugin to facilitate the running of NUnit unit tests on .Net assemblies. ",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
I've had trouble trying to get the nunit gulp task to pass even when tests are failing. This is needed when running this task in TeamCity and using the mute test option.

By allowing the plugin to not fail, I can use plugins like gulp-stats to show how much time everything took, and of course not fail on TeamCity if something goes haywire.
