### PR TITLE
call mono for none window platforms

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -13,7 +13,8 @@ var _ = require('lodash'),
 	PLUGIN_NAME = 'gulp-nunit-runner',
 	NUNIT_CONSOLE = 'nunit-console.exe',
 	NUNIT_X86_CONSOLE = 'nunit-console-x86.exe',
-
+	
+	isWin = /^win/.test(process.platform),
 	runner;
 
 // Main entry point
@@ -65,7 +66,7 @@ runner.getArguments = function (options, assemblies) {
 function parseSwitches(options) {
 	var filtered,
 		switches,
-		isWin = /^win/.test(process.platform),
+		
 	// when running under mono on linux/mac switches must be specified with a - not a /
 		switchChar = isWin ? '/' : '-';
 
@@ -136,6 +137,11 @@ function run(stream, files, options) {
 
 	exe = runner.getExecutable(options);
 	args = runner.getArguments(options, assemblies);
+
+	if(!isWin){
+		args.unshift(exe);
+		exe = "mono";
+	}
 
 	child = child_process.spawn(exe, args, opts);
 


### PR DESCRIPTION
not really tested (need to run on linux mono, it does not like windows mono, seems to be an issue with the exit code)

#20 